### PR TITLE
Add link to vic's timer template

### DIFF
--- a/code.js
+++ b/code.js
@@ -32,7 +32,7 @@ figma.ui.onmessage = msg => {
             pause = true;
             break;
         case 'helpon':
-            figma.ui.resize(220, 150);
+            figma.ui.resize(220, 180);
             break;
         case 'helpoff':
             figma.ui.resize(220, 50);

--- a/code.ts
+++ b/code.ts
@@ -31,7 +31,7 @@ figma.ui.onmessage = msg => {
       break;
 
     case 'helpon':
-      figma.ui.resize(220, 150);
+      figma.ui.resize(220, 180);
       break;
 
     case 'helpoff':

--- a/ui.html
+++ b/ui.html
@@ -28,6 +28,9 @@
 <b id="helptext" hidden> <br /> <br /> 
   Type the time you want to count down in Timer: HH:MM:SS format (e.g. Timer: 5:00) in any text field, then press 'Start'.
   You can also use HH:MM:SS format (e.g. 5:00). In this case you need to select the text layer before pressing 'Start'.
+  <br />
+  <br />
+  <a href="https://www.figma.com/community/file/824677652393376493" target="_blank">Download timer template</a> <div> from the Figma community.</div>
  </b>
 
 </html>


### PR DESCRIPTION
resolves #12 - added a link to download Vic's timer template in the helptext. Also wondering how Github will deal with these conflicts, as this branch didn't have the updated code from the font size & weigth fix yet.

<img width="282" alt="Screenshot 2020-05-05 at 21 41 41" src="https://user-images.githubusercontent.com/2196784/81108596-3850df80-8f19-11ea-815e-1e21892746a5.png">
